### PR TITLE
Add a section for trainings

### DIFF
--- a/content/blog/trainings/index.md
+++ b/content/blog/trainings/index.md
@@ -1,0 +1,15 @@
+---
+title: Trainings
+description: Trainings provided for red teaming and penetration testing
+---
+
+## Available Trainings
+
+1. **Red Teaming Basics**
+   - Description: Introduction to red teaming concepts and methodologies.
+2. **Advanced Red Teaming**
+   - Description: In-depth training on advanced red teaming techniques and tools.
+3. **Penetration Testing Fundamentals**
+   - Description: Basic principles and practices of penetration testing.
+4. **Advanced Penetration Testing**
+   - Description: Advanced techniques and tools for penetration testing.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,6 +27,13 @@ module.exports = {
       },
     },
     {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        path: `${__dirname}/content/blog/trainings`,
+        name: `trainings`,
+      },
+    },
+    {
       resolve: `gatsby-transformer-remark`,
       options: {
         plugins: [

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,6 +8,7 @@ import SEO from "../components/seo"
 const BlogIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`
   const posts = data.allMarkdownRemark.nodes
+  const trainings = data.allMarkdownRemark.nodes.filter(post => post.fields.slug.includes('/trainings/'))
 
   if (posts.length === 0) {
     return (
@@ -50,6 +51,39 @@ const BlogIndex = ({ data, location }) => {
                   <p
                     dangerouslySetInnerHTML={{
                       __html: post.frontmatter.description || post.excerpt,
+                    }}
+                    itemProp="description"
+                  />
+                </section>
+              </article>
+            </li>
+          )
+        })}
+      </ol>
+      <h2>Trainings</h2>
+      <ol style={{ listStyle: `none` }}>
+        {trainings.map(training => {
+          const title = training.frontmatter.title || training.fields.slug
+
+          return (
+            <li key={training.fields.slug}>
+              <article
+                className="post-list-item"
+                itemScope
+                itemType="http://schema.org/Article"
+              >
+                <header>
+                  <h2>
+                    <Link to={training.fields.slug} itemProp="url">
+                      <span itemProp="headline">{title}</span>
+                    </Link>
+                  </h2>
+                  <small>{training.frontmatter.date}</small>
+                </header>
+                <section>
+                  <p
+                    dangerouslySetInnerHTML={{
+                      __html: training.frontmatter.description || training.excerpt,
                     }}
                     itemProp="description"
                   />

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -16,6 +16,8 @@ const BlogPostTemplate = (props) => {
     config: { identifier: props.uri.substring(1), siteTitle},
   }
   
+  const trainings = data.allMarkdownRemark.nodes.filter(post => post.fields.slug.includes('/trainings/'))
+
   return (
     <Layout location={location} title={siteTitle}>
       <SEO
@@ -67,6 +69,39 @@ const BlogPostTemplate = (props) => {
           </li>
         </ul>
       </nav>
+      <h2>Trainings</h2>
+      <ol style={{ listStyle: `none` }}>
+        {trainings.map(training => {
+          const title = training.frontmatter.title || training.fields.slug
+
+          return (
+            <li key={training.fields.slug}>
+              <article
+                className="post-list-item"
+                itemScope
+                itemType="http://schema.org/Article"
+              >
+                <header>
+                  <h2>
+                    <Link to={training.fields.slug} itemProp="url">
+                      <span itemProp="headline">{title}</span>
+                    </Link>
+                  </h2>
+                  <small>{training.frontmatter.date}</small>
+                </header>
+                <section>
+                  <p
+                    dangerouslySetInnerHTML={{
+                      __html: training.frontmatter.description || training.excerpt,
+                    }}
+                    itemProp="description"
+                  />
+                </section>
+              </article>
+            </li>
+          )
+        })}
+      </ol>
     </Layout>
   )
 }
@@ -108,6 +143,19 @@ export const pageQuery = graphql`
       }
       frontmatter {
         title
+      }
+    }
+    allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
+      nodes {
+        excerpt
+        fields {
+          slug
+        }
+        frontmatter {
+          date(formatString: "MMMM DD, YYYY")
+          title
+          description
+        }
       }
     }
   }


### PR DESCRIPTION
Add a section for trainings provided for red teaming and penetration testing.

* **Add new markdown file**: Add `content/blog/trainings/index.md` with details about the trainings provided for red teaming and penetration testing.
* **Update gatsby-config.js**: Add a new `gatsby-source-filesystem` entry for the `content/blog/trainings` directory.
* **Update src/pages/index.js**: Add a new section for trainings in the blog index, import necessary components and data, and render the trainings section with links to the individual training posts.
* **Update src/templates/blog-post.js**: Add a new section for trainings in the blog post template, import necessary components and data, and render the trainings section with links to the individual training posts.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/smokeme/fawaz.blog?shareId=5b26b9f2-509f-42ac-969a-e4fb031b336b).